### PR TITLE
fix : metadata now uses metadata from sanity

### DIFF
--- a/frontend/src/app/acara/layout.tsx
+++ b/frontend/src/app/acara/layout.tsx
@@ -1,32 +1,41 @@
+import { ReactNode } from "react";
 import { Metadata } from "next";
+import { getSectionMetadata } from "@/sanity/queries";
 
-export const metadata: Metadata = {
-  title: "Acara & Kegiatan | Portal Alumni SMK Telkom Jakarta",
-  description: "Temukan berbagai acara menarik yang diselenggarakan oleh alumni dan SMK Telkom Jakarta. Ikuti networking, workshop, dan kegiatan lainnya.",
-  openGraph: {
-    title: "Acara & Kegiatan | Portal Alumni SMK Telkom Jakarta",
-    description: "Temukan berbagai acara menarik yang diselenggarakan oleh alumni dan SMK Telkom Jakarta.",
-    type: "website",
-    images: [
-      {
-        url: "/acara-hero.jpg",
-        width: 1200,
-        height: 630,
-        alt: "Acara Alumni SMK Telkom Jakarta",
-      },
-    ],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Acara Alumni SMK Telkom Jakarta",
-    description: "Temukan berbagai acara menarik yang diselenggarakan oleh alumni dan SMK Telkom Jakarta.",
-    images: ["/acara-hero.jpg"],
-  },
-  alternates: {
-    canonical: "/acara",
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const meta = await getSectionMetadata("acara");
+  return {
+    title: meta?.title || "Acara & Kegiatan | Portal Alumni SMK Telkom Jakarta",
+    description:
+      meta?.description ||
+      "Temukan berbagai acara menarik yang diselenggarakan oleh alumni dan SMK Telkom Jakarta. Ikuti networking, workshop, dan kegiatan lainnya.",
+    openGraph: {
+      title: meta?.ogTitle || meta?.title,
+      description: meta?.ogDescription || meta?.description,
+      type: "website",
+      images: [
+        {
+          url: meta?.ogImage || "/acara-hero.jpg",
+          width: 1200,
+          height: 630,
+          alt: meta?.ogImageAlt || "Acara Alumni SMK Telkom Jakarta",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: meta?.twitterTitle || meta?.title,
+      description: meta?.twitterDescription || meta?.description,
+      images: [meta?.twitterImage || "/acara-hero.jpg"],
+    },
+    keywords: meta?.keywords || [],
+    alternates: {
+      canonical: "/acara",
+    },
+  };
+}
 
+export const revalidate = 300;
 
 interface AcaraLayoutProps {
   readonly children: React.ReactNode;
@@ -35,4 +44,3 @@ interface AcaraLayoutProps {
 export default function AcaraLayout({ children }: AcaraLayoutProps) {
   return <>{children}</>;
 }
-

--- a/frontend/src/app/alumni/layout.tsx
+++ b/frontend/src/app/alumni/layout.tsx
@@ -32,6 +32,8 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
+export const revalidate = 300;
+
 export default function AlumniLayout({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }

--- a/frontend/src/app/berita/layout.tsx
+++ b/frontend/src/app/berita/layout.tsx
@@ -1,31 +1,41 @@
+import { ReactNode } from "react";
 import { Metadata } from "next";
+import { getSectionMetadata } from "@/sanity/queries";
 
-export const metadata: Metadata = {
-  title: "Berita | Portal Alumni SMK Telkom Jakarta",
-  description: "Berita terbaru dari komunitas alumni SMK Telkom Jakarta. Dapatkan informasi kegiatan, prestasi, dan perkembangan terkini.",
-  openGraph: {
-    title: "Berita | Portal Alumni SMK Telkom Jakarta",
-    description: "Berita terbaru dari komunitas alumni SMK Telkom Jakarta. Dapatkan informasi kegiatan, prestasi, dan perkembangan terkini.",
-    type: "website",
-    images: [
-      {
-        url: "/berita-hero.jpg",
-        width: 1200,
-        height: 630,
-        alt: "Berita Alumni SMK Telkom Jakarta",
-      },
-    ],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Berita Alumni SMK Telkom Jakarta",
-    description: "Berita terbaru dari komunitas alumni SMK Telkom Jakarta.",
-    images: ["/berita-hero.jpg"],
-  },
-  alternates: {
-    canonical: "/berita",
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const meta = await getSectionMetadata("berita");
+  return {
+    title: meta?.title || "Berita | Portal Alumni SMK Telkom Jakarta",
+    description:
+      meta?.description ||
+      "Berita terbaru dari komunitas alumni SMK Telkom Jakarta. Dapatkan informasi kegiatan, prestasi, dan perkembangan terkini.",
+    openGraph: {
+      title: meta?.ogTitle || meta?.title,
+      description: meta?.ogDescription || meta?.description,
+      type: "website",
+      images: [
+        {
+          url: meta?.ogImage || "/berita-hero.jpg",
+          width: 1200,
+          height: 630,
+          alt: meta?.ogImageAlt || "Berita Alumni SMK Telkom Jakarta",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: meta?.twitterTitle || meta?.title,
+      description: meta?.twitterDescription || meta?.description,
+      images: [meta?.twitterImage || "/berita-hero.jpg"],
+    },
+    keywords: meta?.keywords || [],
+    alternates: {
+      canonical: "/berita",
+    },
+  };
+}
+
+export const revalidate = 300;
 
 interface BeritaLayoutProps {
   readonly children: React.ReactNode;
@@ -34,4 +44,3 @@ interface BeritaLayoutProps {
 export default function BeritaLayout({ children }: BeritaLayoutProps) {
   return <>{children}</>;
 }
-

--- a/frontend/src/app/karir/layout.tsx
+++ b/frontend/src/app/karir/layout.tsx
@@ -1,36 +1,46 @@
+import { ReactNode } from "react";
 import { Metadata } from "next";
+import { getSectionMetadata } from "@/sanity/queries";
 
-export const metadata: Metadata = {
-  title: "Lowongan Kerja | Portal Alumni SMK Telkom Jakarta",
-  description: "Temukan peluang karir terbaru yang dibagikan oleh sesama alumni dan perusahaan partner. Dapatkan pekerjaan impian Anda di sini.",
-  openGraph: {
-    title: "Lowongan Kerja | Portal Alumni SMK Telkom Jakarta",
-    description: "Temukan peluang karir terbaru yang dibagikan oleh sesama alumni dan perusahaan partner.",
-    type: "website",
-    images: [
-      {
-        url: "/karir-hero.jpg",
-        width: 1200,
-        height: 630,
-        alt: "Lowongan Kerja Alumni SMK Telkom Jakarta",
-      },
-    ],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Lowongan Kerja Alumni SMK Telkom Jakarta",
-    description: "Temukan peluang karir terbaru yang dibagikan oleh sesama alumni dan perusahaan partner.",
-    images: ["/karir-hero.jpg"],
-  },
-  alternates: {
-    canonical: "/karir",
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const meta = await getSectionMetadata("karir");
+  return {
+    title: meta?.title || "Lowongan Kerja | Portal Alumni SMK Telkom Jakarta",
+    description:
+      meta?.description ||
+      "Temukan peluang karir terbaru yang dibagikan oleh sesama alumni dan perusahaan partner. Dapatkan pekerjaan impian Anda di sini.",
+    openGraph: {
+      title: meta?.ogTitle || meta?.title,
+      description: meta?.ogDescription || meta?.description,
+      type: "website",
+      images: [
+        {
+          url: meta?.ogImage || "/karir-hero.jpg",
+          width: 1200,
+          height: 630,
+          alt: meta?.ogImageAlt || "Lowongan Kerja Alumni SMK Telkom Jakarta",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: meta?.twitterTitle || meta?.title,
+      description: meta?.twitterDescription || meta?.description,
+      images: [meta?.twitterImage || "/karir-hero.jpg"],
+    },
+    keywords: meta?.keywords || [],
+    alternates: {
+      canonical: "/karir",
+    },
+  };
+}
 
-export default function KarirLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export const revalidate = 300;
+
+interface KarirLayoutProps {
+  readonly children: React.ReactNode;
+}
+
+export default function KarirLayout({ children }: KarirLayoutProps) {
   return <>{children}</>;
 }

--- a/frontend/src/app/tentang/layout.tsx
+++ b/frontend/src/app/tentang/layout.tsx
@@ -32,6 +32,8 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
+export const revalidate = 300;
+
 export default function TentangLayout({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Acara, Berita, and Karir pages now use dynamic, CMS-driven SEO metadata (titles, descriptions, keywords, Open Graph/Twitter cards) for richer search and sharing previews.
  * Faster content freshness: Acara, Alumni, Berita, Karir, and Tentang pages automatically revalidate approximately every 5 minutes, ensuring updates appear without manual redeploys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->